### PR TITLE
Add ability to rejoin game

### DIFF
--- a/avalon.js
+++ b/avalon.js
@@ -27,13 +27,14 @@ store.init(
         })
       })
 
-      socket.on('rejoinGame', (playerId) => {
+      socket.on('rejoinGame', (playerId, fn) => {
         console.log(socket.id + ' rejoinGame '  + playerId)
         socket.join(playerId)
         model.fetchState(playerId, (state) => {
           if (state) {
             socket.emit('game', state)
           }
+          fn({success: state ? true : false})
         })
       })
 

--- a/avalon.js
+++ b/avalon.js
@@ -12,6 +12,7 @@ store.init(
         console.log(socket.id + ' createGame ' + playerName)
         const gameId = randomId()
         const playerId = randomId()
+        socket.join(playerId)
         model.createGame(gameId, playerId, playerName, ({success}) => {
           fn({gameId, playerId, success})
         })
@@ -20,9 +21,26 @@ store.init(
       socket.on('joinGame', (gameId, playerName, fn) => {
         console.log(socket.id + ' joinGame ' + gameId + ' ' + playerName)
         const playerId = randomId()
+        socket.join(playerId)
         model.joinGame(gameId, playerId, playerName, ({success}) => {
           fn({playerId, success})
         })
+      })
+
+      socket.on('rejoinGame', (playerId) => {
+        console.log(socket.id + ' rejoinGame '  + playerId)
+        socket.join(playerId)
+        model.fetchState(playerId, (state) => {
+          if (state) {
+            socket.emit('game', state)
+          }
+        })
+      })
+
+      socket.on('leaveGame', (playerId, fn) => {
+        console.log(socket.id + ' leaveGame ' + playerId)
+        socket.leave(playerId)
+        fn({})
       })
 
       socket.on('startGame', (gameId, playerId, playerName, roleList, playerOrder, fn) => {
@@ -45,24 +63,6 @@ store.init(
         model.voteInQuest(questId, playerId, playerName, vote, fn)
       })
 
-      socket.on('subscribe', (gameId, playerId, fn) => {
-        console.log(socket.id + ' subscribe ' + gameId + ' ' + playerId)
-        model.fetchState(gameId, playerId, (state) => {
-          if (!state) {
-            fn({success: false})
-          } else {
-            socket.join(gameId + playerId)
-            fn({'game': state, success: true})
-          }
-        })
-      })
-
-      socket.on('unsubscribe', (gameId, playerId, fn) => {
-        console.log(socket.id + ' unsubscribe ' + gameId + ' ' + playerId)
-        socket.leave(gameId + playerId)
-        fn({})
-      })
-
       socket.on('disconnect', () => {
         console.log(socket.id + ' disconnect')
       })
@@ -70,7 +70,7 @@ store.init(
   },
   (states) => {
     console.log('received update')
-    Object.entries(states).forEach(([playerId, state]) => io.to(state.id + playerId).emit('game', state))
+    Object.entries(states).forEach(([playerId, state]) => io.to(playerId).emit('game', state))
   }
 )
 

--- a/store.js
+++ b/store.js
@@ -131,8 +131,8 @@ const GameModel = (games) => ({
   voteInQuest: (questId, playerId, playerName, vote, fn) => {
     fn({success: false})
   },
-  fetchState: (gameId, playerId, fn) => {
-    games.findOne({id: gameId, 'players.id': playerId}, (err, game) => {
+  fetchState: (playerId, fn) => {
+    games.findOne({'players.id': playerId}, (err, game) => {
       if (err) {
         console.error(err)
         fn(null)
@@ -181,7 +181,7 @@ const cmp = (key) => (a, b) => {
   return 0
 }
 
-const randomId = () => Math.random().toString(36).substring(2, 12)
+const randomId = () => Math.random().toString(36).substring(2)
 
 const createPlayer = (playerId, playerName) => ({
   id: playerId, name: playerName, role: null, order: 0


### PR DESCRIPTION
`createGame` and `joinGame` auto-subscribes you to the game

`rejoinGame` should be called on socket reconnect or when joining from a different tab/device/etc

`rejoinGame` emits a `state` event so the client knows the current state. `createGame` and `joinGame` will both emit `state` events if the database write is successful